### PR TITLE
Frontend improvements for the map

### DIFF
--- a/src/nursery-nav/src/components/Filters/Filters.tsx
+++ b/src/nursery-nav/src/components/Filters/Filters.tsx
@@ -20,8 +20,6 @@ export default function Filters({ defaultVoivodeship, defaultCity, isMobile, cit
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
 
-    console.log(citiesResponse);
-
     const [institutionsAutocomplete, setInstitutionsAutocomplete] = useState<InstitutionAutocomplete[]>([]);
     const voivodeships = [
         'DOLNOŚLĄSKIE',

--- a/src/nursery-nav/src/components/Filters/Filters.tsx
+++ b/src/nursery-nav/src/components/Filters/Filters.tsx
@@ -101,7 +101,7 @@ export default function Filters({ defaultVoivodeship, defaultCity, isMobile, cit
                     options={cities.filter(city =>
                         (defaultVoivodeship && city.voivodeship === defaultVoivodeship) ||
                         (!defaultVoivodeship && (!searchParams.get('voivodeship') || city.voivodeship === searchParams.get('voivodeship'))))?.map(city => city.city) || []}
-                    value={searchParams.get('city') || ''}
+                    value={searchParams.get('city') || null}
                     onChange={(_event, value) => {
                         if (!value && searchParams.has('city')) {
                             searchParams.delete('city');
@@ -119,10 +119,10 @@ export default function Filters({ defaultVoivodeship, defaultCity, isMobile, cit
             }
 
             {!defaultVoivodeship &&
-                < Autocomplete
+                <Autocomplete
                     id="voivodeshipFilter"
                     options={voivodeships || []}
-                    value={searchParams.get('voivodeship') || ''}
+                    value={searchParams.get('voivodeship') || null}
                     onChange={(_event, value) => {
                         if (!value && searchParams.has('voivodeship')) {
                             searchParams.delete('voivodeship');

--- a/src/nursery-nav/src/components/ListComponent/ListComponent.tsx
+++ b/src/nursery-nav/src/components/ListComponent/ListComponent.tsx
@@ -75,7 +75,7 @@ export default function ListComponent({ defaultVoivodeship, defaultCity }: ListC
 				setTotalPages(data.totalPages);
 				setInstitutionIds(data.ids);
 			} catch (error) {
-				console.log(error);
+				console.error(error);
 			}
 			setLoading(false);
 		};

--- a/src/nursery-nav/src/components/MapComponent/MapComponent.tsx
+++ b/src/nursery-nav/src/components/MapComponent/MapComponent.tsx
@@ -15,9 +15,10 @@ import PathConstants from '../../shared/pathConstants';
 
 interface MapComponentProps {
 	locations: LocationResponse[];
+	setIsMapLoaded: (isMapLoaded: boolean) => void;
 }
 
-export default function MapComponent({ locations }: MapComponentProps) {
+export default function MapComponent({ locations, setIsMapLoaded }: MapComponentProps) {
 	const { institutionIds } = useContext(InstitutionContext);
 	const [locationsFiltered, setLocationsFiltered] = useState<LocationResponse[]>([]);
 
@@ -70,11 +71,15 @@ export default function MapComponent({ locations }: MapComponentProps) {
 						attribution={attributionText}
 						url={mapUrl}
 						maxZoom={20}
+						eventHandlers={{
+							load: () => setIsMapLoaded(true),
+						}}
 					/>
 					<MarkerClusterGroup
 						className="marker-cluster-group"
 						polygonOptions={{ opacity: 0 }}
-						chunkedLoading>
+						chunkedLoading
+					>
 						{markers}
 					</MarkerClusterGroup>
 				</MapContainer>

--- a/src/nursery-nav/src/components/MapPin/MapPin.tsx
+++ b/src/nursery-nav/src/components/MapPin/MapPin.tsx
@@ -1,11 +1,15 @@
-import { Marker, useMap } from 'react-leaflet';
-import { Crib } from '@mui/icons-material';
-import { divIcon } from 'leaflet';
+import { useEffect } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { InstitutionType } from '../../shared/nursery.interface';
-import './MapPin.css';
 import { useNavigate, generatePath } from 'react-router-dom';
+import { Marker, useMap } from 'react-leaflet';
+
+import { divIcon } from 'leaflet';
+import { Crib } from '@mui/icons-material';
+
+import { InstitutionType } from '../../shared/nursery.interface';
 import PathConstants from '../../shared/pathConstants';
+
+import './MapPin.css';
 
 export interface MapPinProps {
 	institutionType: InstitutionType;
@@ -20,11 +24,12 @@ export default function MapPin(props: MapPinProps) {
 	const map = useMap();
 	const navigate = useNavigate();
 
-	if (props.selectedLocationLat !== undefined && props.selectedLocationLon !== undefined) {
-		map.setView([props.selectedLocationLat, props.selectedLocationLon], 18, {
-			animate: true
-		});
-	}
+	// Update map view only if necessary
+	useEffect(() => {
+		if (props.selectedLocationLat !== undefined && props.selectedLocationLon !== undefined) {
+			map.setView([props.selectedLocationLat, props.selectedLocationLon], 18, { animate: true });
+		}
+	}, [props.selectedLocationLat, props.selectedLocationLon, map]);
 
 	const position: [number, number] = [props.latitude, props.longitude];
 	const institutionType = props.institutionType === InstitutionType.NURSERY ? 'nursery' : 'childclub';
@@ -32,6 +37,7 @@ export default function MapPin(props: MapPinProps) {
 
 	return (
 		<Marker
+			aria-label={`Details for ${institutionType} with ID ${props.id}`}
 			eventHandlers={{
 				click: () => {
 					navigate(generatePath(PathConstants.INSTITUTION_DETAILS, { id: props.id }));

--- a/src/nursery-nav/src/pages/InstitutionDetailsPage.tsx
+++ b/src/nursery-nav/src/pages/InstitutionDetailsPage.tsx
@@ -13,6 +13,7 @@ export default function InstitutionDetailsPage() {
     const [locations, setLocations] = useState<LocationResponse[]>([]);
     const [selectedInstitution, setSelectedInstitution] = useState<Institution | null>(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [isMapLoaded, setIsMapLoaded] = useState(false);
 
     useEffect(() => {
         const fetchInstitution = async () => {
@@ -61,7 +62,7 @@ export default function InstitutionDetailsPage() {
                 {selectedInstitution && <InstitutionDetails {...selectedInstitution} />}
             </Grid>
             <Grid item display={{ xs: "none", md: "block" }} md={6}>
-                {isLoading ? <CircularProgress /> : <MapComponent locations={locations} />}
+                {(isLoading && !isMapLoaded) ? <CircularProgress /> : <MapComponent locations={locations} setIsMapLoaded={setIsMapLoaded} />}
             </Grid>
         </>
     );

--- a/src/nursery-nav/src/pages/ListPage.tsx
+++ b/src/nursery-nav/src/pages/ListPage.tsx
@@ -1,4 +1,4 @@
-import { Grid, CircularProgress } from "@mui/material";
+import { Grid, CircularProgress, Box } from "@mui/material";
 import ListComponent from "../components/ListComponent/ListComponent";
 import MapComponent from "../components/MapComponent/MapComponent";
 import FiltersBar from "../components/Filters/FiltersBar";
@@ -18,6 +18,7 @@ export default function ListPage() {
     const [isMobile, setIsMobile] = useState(window.innerWidth < 600);
     const [locations, setLocations] = useState<LocationResponse[]>([]);
     const [isLoading, setIsLoading] = useState(true); // Add loading state
+    const [isMapLoaded, setIsMapLoaded] = useState(false);
     const [cities, setCities] = useState<getCitiesResponse[]>();
 
     useLayoutEffect(() => {
@@ -31,13 +32,11 @@ export default function ListPage() {
 
     useEffect(() => {
         const fetchData = async () => {
-            setIsLoading(true); // Set loading state to true before fetching data
             const locations = await getLocations();
             setLocations(locations);
-            setIsLoading(false); // Set loading state to false after fetching data
         };
 
-        fetchData();
+        fetchData().then(() => setIsLoading(false));
     }, []);
 
     useEffect(() => {
@@ -76,10 +75,12 @@ export default function ListPage() {
             </Grid>
             {!isMobile && (
                 <Grid item xs={12} md={6} sx={{ display: { xs: "none", md: "block" } }}>
-                    {isLoading ? (
-                        <CircularProgress /> // Render loading animation when isLoading is true
+                    {(isLoading && !isMapLoaded) ? (
+                        <Box alignItems="center" justifyContent={"center"} display="flex" height="100%" width="100%">
+                            <CircularProgress />
+                        </Box>
                     ) : (
-                        <MapComponent locations={locations} />
+                        <MapComponent locations={locations} setIsMapLoaded={setIsMapLoaded} />
                     )}
                 </Grid>
             )}

--- a/src/nursery-nav/src/pages/MapPage.tsx
+++ b/src/nursery-nav/src/pages/MapPage.tsx
@@ -23,6 +23,7 @@ export default function MapPage() {
 
     const [locations, setLocations] = useState<LocationResponse[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [isMapLoaded, setIsMapLoaded] = useState(false);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -56,10 +57,11 @@ export default function MapPage() {
                 <ListComponent defaultVoivodeship={voivodeship} defaultCity={city} />
             </Grid>
             <Grid item xs={12} md={6}>
-                {isLoading ?
+                {(isLoading && !isMapLoaded) ?
                     <CircularProgress />
                     :
-                    <MapComponent locations={locations} />}
+                    <MapComponent locations={locations} setIsMapLoaded={setIsMapLoaded} />
+                }
             </Grid>
         </>
     );


### PR DESCRIPTION
This PR adds a couple of improvements to the map component:
- memorize location filtering
- move detecting screen size to the useEffect hook with an addition of debounce method
- add the second boolean variable to indicate that the map tile is loading
- remove the redundant console.logs
- get rid of MaterialUI Autocomplete warnings